### PR TITLE
Update initial custom server script

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -184,7 +184,7 @@ class Server extends Model
      */
     public function provisionCommand(): HtmlString
     {
-        return new HtmlString("mkdir -p /root/.ssh && touch /root/.ssh/authorized_keys && chmod -R go-rwx /root/.ssh/ && wget --no-verbose -O - {$this->provisionScriptUrl()} | bash");
+        return new HtmlString("mkdir -p /root/.ssh && touch /root/.ssh/authorized_keys && chmod go-rwx /root/.ssh/ && chmod go-rwx /root/.ssh/authorized_keys && wget --no-verbose -O - {$this->provisionScriptUrl()} | bash");
     }
 
     /**

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -184,7 +184,7 @@ class Server extends Model
      */
     public function provisionCommand(): HtmlString
     {
-        return new HtmlString("wget --no-verbose -O - {$this->provisionScriptUrl()} | bash");
+        return new HtmlString("mkdir -p /root/.ssh && touch /root/.ssh/authorized_keys && chmod -R go-rwx /root/.ssh/ && wget --no-verbose -O - {$this->provisionScriptUrl()} | bash");
     }
 
     /**


### PR DESCRIPTION
Update app/Models/Server.php to ensure `/root/.ssh/authorized_keys` is present on newly installed custom servers.

This might be needed in the case of some server installs which do not create root's .ssh/ subdirectory. In these cases, the existing wget will work but the append of the initial root public key to the authorized_keys file will fail, requiring manual intervention to add the needed directory and file, including setting the right permissions.