### PR TITLE
Conditionally hide the register button on the welcome.blade.php page

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -33,12 +33,14 @@
                 >
                     Log in
                 </Link>
+                @if (Route::has('register'))
                 <Link
                     href="{{ route('register') }}"
                     class="rounded-md border border-transparent bg-indigo-500 px-4 py-2 font-bold text-white shadow-sm hover:bg-indigo-700 focus:border-indigo-300 focus:outline-none focus:ring focus:ring-indigo-200 focus:ring-opacity-50"
                 >
                     Register
                 </Link>
+                @endif
             @endguest
         </div>
     </div>


### PR DESCRIPTION
Dear @pascalbaljet,

here's a small fix to the default welcome.blade.php page, which hides the Register button depending on whether the `Features::registration()` in `config/fortify.php` is enabled.

Thanks a lot for Eddy and keep up the good work.

Kind regards,
g